### PR TITLE
linuxdeployqt

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The Qt framework has surprisingly many tools that don't get the spotlight.  This
 - [moc-ng](https://github.com/woboq/moc-ng) [:octocat:](https://github.com/woboq/moc-ng) - Alternative implementation of `moc` that's binary-compatible with Qt's version.
 - [Qt-Inspector](https://github.com/robertknight/Qt-Inspector) [:octocat:](https://github.com/robertknight/Qt-Inspector) - Inspection tool with similar goals to GammaRay, though much simpler.
 - [SIP](https://www.riverbankcomputing.com/software/sip) [:package:](https://www.riverbankcomputing.com/hg/sip) - Generates Python bindings for C or C++ libraries.  Has special support for Qt signals and slots, and was used to create [PyQt](https://riverbankcomputing.com/software/pyqt).
+- [linuxdeployqt](https://github.com/probonopd/linuxdeployqt/) [:octocat:](https://github.com/probonopd/linuxdeployqt/) - Lets you bundle your Qt based application as an AppDir or [AppImage](http://appimage.org/), making it possible to ship it to users of many desktop Linux distributions. Similar to the official `windeployqt` and `macdeployqt` tools but for Linux.
 
 ## Bindings in Other Languages
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The Qt framework has surprisingly many tools that don't get the spotlight.  This
 - [moc-ng](https://github.com/woboq/moc-ng) [:octocat:](https://github.com/woboq/moc-ng) - Alternative implementation of `moc` that's binary-compatible with Qt's version.
 - [Qt-Inspector](https://github.com/robertknight/Qt-Inspector) [:octocat:](https://github.com/robertknight/Qt-Inspector) - Inspection tool with similar goals to GammaRay, though much simpler.
 - [SIP](https://www.riverbankcomputing.com/software/sip) [:package:](https://www.riverbankcomputing.com/hg/sip) - Generates Python bindings for C or C++ libraries.  Has special support for Qt signals and slots, and was used to create [PyQt](https://riverbankcomputing.com/software/pyqt).
-- [linuxdeployqt](https://github.com/probonopd/linuxdeployqt/) [:octocat:](https://github.com/probonopd/linuxdeployqt/) - Lets you bundle your Qt based application as an AppDir or [AppImage](http://appimage.org/), making it possible to ship it to users of many desktop Linux distributions. Similar to the official `windeployqt` and `macdeployqt` tools but for Linux.
+- [linuxdeployqt](https://github.com/probonopd/linuxdeployqt) [:octocat:](https://github.com/probonopd/linuxdeployqt) - Lets you bundle your Qt based application as an AppDir or [AppImage](http://appimage.org), making it possible to ship it to users of many desktop Linux distributions. Similar to the official `windeployqt` and `macdeployqt` tools but for Linux.
 
 ## Bindings in Other Languages
 


### PR DESCRIPTION
[linuxdeployqt](https://github.com/probonopd/linuxdeployqt/) [:octocat:](https://github.com/probonopd/linuxdeployqt/) - Lets you bundle your Qt based application as an AppDir or [AppImage](http://appimage.org/), making it possible to ship it to users of many desktop Linux distributions. Similar to the official `windeployqt` and `macdeployqt` tools but for Linux.